### PR TITLE
feat: export workloads to a file/folder structure

### DIFF
--- a/docs/content/3-user-documentation/using-cli.md
+++ b/docs/content/3-user-documentation/using-cli.md
@@ -74,3 +74,16 @@ Account ID you can execute the following command:
 ```shell
 landingzone-organization account view <ACCOUNT_ID>
 ```
+
+## Export your workload structure
+
+In order to enable git approval flows for your workloads you will need a file structure. The following command will create this structure for you:   
+
+```shell
+landingzone-organization export workloads "./workloads" "workloads"
+```
+
+The following will happen:
+1. This will take all the workloads located in the `workloads` organization unit. 
+2. For each workload a folder is created in the `./workloads` folder.
+3. Within the workload folder a: `info.yaml` and a `<ENVIRONMENT>.yaml` per environment is generated.

--- a/landingzone_organization/cli/commands/export.py
+++ b/landingzone_organization/cli/commands/export.py
@@ -30,4 +30,3 @@ def workloads(ctx: Context, config_path: str, ou_path: str) -> None:
         WorkloadGenerator(config_path=config_path, workload=workload).execute()
 
     list(map(handle_workload, workloads))
-

--- a/landingzone_organization/cli/commands/export.py
+++ b/landingzone_organization/cli/commands/export.py
@@ -1,0 +1,33 @@
+import configparser
+import os
+
+import click
+
+from landingzone_organization import Workload
+from landingzone_organization.cli import Context
+from landingzone_organization.workload_generator import WorkloadGenerator
+
+
+@click.group()
+def cli():
+    """Perform profiles operations"""
+    pass
+
+
+@cli.command()
+@click.argument("config-path")
+@click.argument("ou-path")
+@click.pass_obj
+def workloads(ctx: Context, config_path: str, ou_path: str) -> None:
+    """
+    Export the workloads in the supplied path
+    """
+    ctx.info("Prepare the folder structure based on the organisation structure")
+    workloads = ctx.organization.workloads(ou_path.split("/"))
+    ctx.debug(f"\tFound {len(workloads)} workloads")
+
+    def handle_workload(workload: Workload) -> None:
+        WorkloadGenerator(config_path=config_path, workload=workload).execute()
+
+    list(map(handle_workload, workloads))
+

--- a/landingzone_organization/cli/context.py
+++ b/landingzone_organization/cli/context.py
@@ -18,9 +18,13 @@ class Context:
     def session(self) -> Session:
         return boto3.session.Session(profile_name=self.__profile)
 
-    @property
-    def debug(self):
-        return self.__debug
+    def debug(self, message: str) -> None:
+        if self.__debug:
+            click.echo(message)
+
+    @staticmethod
+    def info(message: str) -> None:
+        click.echo(message)
 
     @property
     def data_file(self):

--- a/landingzone_organization/workload.py
+++ b/landingzone_organization/workload.py
@@ -33,4 +33,3 @@ class Workload:
     @staticmethod
     def from_dict(data: dict, accounts: List[Account]) -> Workload:
         return Workload(name=data["Name"], accounts=accounts)
-

--- a/landingzone_organization/workload_generator.py
+++ b/landingzone_organization/workload_generator.py
@@ -1,0 +1,55 @@
+import os
+import yaml
+from landingzone_organization.workload import Workload
+from landingzone_organization.account import Account
+
+
+class WorkloadGenerator:
+    def __init__(self, config_path: str, workload: Workload) -> None:
+        self.__config_path = config_path
+        self.__workload = workload
+
+    def execute(self) -> None:
+        path = os.path.abspath(os.path.join(self.__config_path, self.__workload.name))
+        self.__prepare_workload_folder(path)
+
+    @staticmethod
+    def __ensure_folder(path: str) -> None:
+        if not os.path.isdir(path):
+            os.mkdir(path)
+
+    def __resolve_workload_info(self, file: str) -> dict:
+        info = {
+            "Name": self.__workload.name,
+            "Environments": self.__workload.environments,
+        }
+
+        if os.path.isfile(file):
+            with open(file, "r") as fh:
+                info = yaml.safe_load(fh)
+                info["Name"] = self.__workload.name
+                info["Environments"] = self.__workload.environments
+
+        return info
+
+    @staticmethod
+    def __resolve_account_info(account: Account) -> dict:
+        return {
+            "Name": account.name,
+            "AccountId": account.account_id,
+        }
+
+    def __prepare_workload_folder(self, path: str) -> None:
+        self.__ensure_folder(path)
+        file = os.path.join(path, "info.yaml")
+        info = self.__resolve_workload_info(file)
+
+        with open(file, "w") as fh:
+            yaml.dump(info, fh, sort_keys=False)
+
+        for account in self.__workload.accounts:
+            environment_file = os.path.join(path, f"{account.environment}.yaml")
+
+            if not os.path.isfile(environment_file):
+                with open(environment_file, "w") as fh:
+                    yaml.dump(self.__resolve_account_info(account), fh, sort_keys=False)

--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -41,6 +41,7 @@ def test_context_info(monkeypatch) -> None:
 
     assert context.session.profile_name == "default"
 
+
 def test_context_explicit_profile(monkeypatch) -> None:
     monkeypatch.delenv("AWS_PROFILE", raising=False)
     context = Context(False, "my-profile")

--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -11,22 +11,39 @@ from landingzone_organization.cli import Context
 
 def test_context_default(monkeypatch) -> None:
     monkeypatch.delenv("AWS_PROFILE", raising=False)
-    context = Context(False, None)
-    assert context.debug is False
+
+    with patch("click.echo") as mock_click:
+        context = Context(False, None)
+        context.debug("my message")
+        mock_click.assert_called is False
+
     assert context.session.profile_name == "default"
 
 
 def test_context_debug(monkeypatch) -> None:
     monkeypatch.delenv("AWS_PROFILE", raising=False)
-    context = Context(True, None)
-    assert context.debug is True
+
+    with patch("click.echo") as mock_click:
+        context = Context(True, None)
+        context.debug("my message")
+        mock_click.assert_called_with("my message")
+
     assert context.session.profile_name == "default"
 
+
+def test_context_info(monkeypatch) -> None:
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+
+    with patch("click.echo") as mock_click:
+        context = Context(False, None)
+        context.info("my message")
+        mock_click.assert_called_with("my message")
+
+    assert context.session.profile_name == "default"
 
 def test_context_explicit_profile(monkeypatch) -> None:
     monkeypatch.delenv("AWS_PROFILE", raising=False)
     context = Context(False, "my-profile")
-    assert context.debug is False
 
     try:
         context.session.profile_name
@@ -37,7 +54,6 @@ def test_context_explicit_profile(monkeypatch) -> None:
 def test_context_implicit_profile(monkeypatch) -> None:
     monkeypatch.setenv("AWS_PROFILE", "my-profile")
     context = Context(False, None)
-    assert context.debug is False
 
     try:
         context.session.profile_name

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -1,0 +1,24 @@
+import os
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from landingzone_organization import Organization
+from landingzone_organization.cli import cli
+
+
+@patch("landingzone_organization.workload_generator.WorkloadGenerator")
+@patch("landingzone_organization.AWSOrganization")
+@patch("boto3.session.Session")
+def test_prepare(
+    mock_session, mock_organization, mock_workload_generator, organization: Organization
+) -> None:
+    mock_organization.return_value.parse.return_value = organization
+
+    config_path = os.path.join(os.path.dirname(__file__), "workloads")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["export", "workloads", config_path, "Workloads"])
+
+    assert mock_workload_generator.return_value.execute.called is True
+
+    assert result.exit_code == 0

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
 
 from click.testing import CliRunner
 
@@ -8,17 +8,17 @@ from landingzone_organization.cli import cli
 
 
 @patch("landingzone_organization.workload_generator.WorkloadGenerator")
-@patch("landingzone_organization.AWSOrganization")
 @patch("boto3.session.Session")
-def test_prepare(
-    mock_session, mock_organization, mock_workload_generator, organization: Organization
+def test_export_workloads(
+    mock_session, mock_workload_generator, organization: Organization
 ) -> None:
-    mock_organization.return_value.parse.return_value = organization
-
-    config_path = os.path.join(os.path.dirname(__file__), "workloads")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["export", "workloads", config_path, "Workloads"])
+    with patch(
+        "landingzone_organization.cli.context.open",
+        mock_open(read_data=organization.dump()),
+    ):
+        config_path = os.path.join(os.path.dirname(__file__), "workloads")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["export", "workloads", config_path, "Workloads"])
 
     assert mock_workload_generator.return_value.execute.called is True
-
     assert result.exit_code == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from landingzone_organization import (
     Groups,
     Organization,
     OrganizationUnit,
-    Workload
+    Workload,
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from landingzone_organization import (
@@ -6,7 +7,13 @@ from landingzone_organization import (
     Groups,
     Organization,
     OrganizationUnit,
+    Workload
 )
+
+
+@pytest.fixture
+def config_path() -> str:
+    return os.path.join(os.path.dirname(__file__), "workloads")
 
 
 @pytest.fixture
@@ -22,6 +29,11 @@ def groups(organization) -> Groups:
         ],
         organization=organization,
     )
+
+
+@pytest.fixture
+def workload(organization) -> Workload:
+    return organization.workloads(["Workloads"]).by_name("workload-1")
 
 
 @pytest.fixture

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -1,5 +1,6 @@
 from landingzone_organization import Workload
 
+
 def test_workload_environment_order(organization) -> None:
     workload = organization.workloads(["Workloads"]).by_name("workload-1")
     assert [

--- a/tests/test_workload_generator.py
+++ b/tests/test_workload_generator.py
@@ -1,0 +1,132 @@
+from unittest.mock import mock_open, patch, call
+
+from landingzone_organization.workload import Workload
+from landingzone_organization.workload_generator import WorkloadGenerator
+
+
+@patch("os.path.isfile")
+@patch("os.path.isdir")
+@patch("os.mkdir")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_new_workload(
+    mock_file, mock_mkdir, mock_isdir, mock_isfile, config_path: str, workload: Workload
+) -> None:
+    mock_isdir.return_value = False
+    mock_isfile.return_value = False
+    mock_file.return_value.write.return_value = None
+    generator = WorkloadGenerator(config_path=config_path, workload=workload)
+    generator.execute()
+
+    assert mock_mkdir.called is True
+
+    assert mock_file.call_args_list == [
+        call(f"{config_path}/workload-1/info.yaml", "w"),
+        call(f"{config_path}/workload-1/development.yaml", "w"),
+        call(f"{config_path}/workload-1/testing.yaml", "w"),
+        call(f"{config_path}/workload-1/acceptance.yaml", "w"),
+        call(f"{config_path}/workload-1/production.yaml", "w"),
+    ]
+
+
+@patch("os.path.isfile")
+@patch("os.path.isdir")
+@patch("os.mkdir")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_existing_workload(
+    mock_file, mock_mkdir, mock_isdir, mock_isfile, config_path: str, workload: Workload
+) -> None:
+    mock_isdir.return_value = True
+    mock_isfile.return_value = True
+    mock_file.return_value.write.return_value = None
+
+    generator = WorkloadGenerator(config_path=config_path, workload=workload)
+
+    with patch("yaml.safe_load") as mock_load:
+        mock_load.return_value = {"Name": "workload-1"}
+        generator.execute()
+
+    assert mock_mkdir.called is False
+
+    assert mock_file().write.call_args_list == [
+        call("Name"),
+        call(":"),
+        call(" "),
+        call("workload-1"),
+        call("\n"),
+        call("Environments"),
+        call(":"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("development"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("testing"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("acceptance"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("production"),
+        call("\n"),
+    ]
+    assert mock_file.call_args_list == [
+        call(f"{config_path}/workload-1/info.yaml", "r"),
+        call(f"{config_path}/workload-1/info.yaml", "w"),
+        call(),
+    ]
+
+
+@patch("os.path.isfile")
+@patch("os.path.isdir")
+@patch("os.mkdir")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_existing_workload_new_name(
+    mock_file, mock_mkdir, mock_isdir, mock_isfile, config_path: str, workload: Workload
+) -> None:
+    mock_isdir.return_value = True
+    mock_isfile.return_value = True
+    mock_file.return_value.write.return_value = None
+
+    generator = WorkloadGenerator(config_path=config_path, workload=workload)
+
+    with patch("yaml.safe_load") as mock_load:
+        mock_load.return_value = {"Name": "old-workload"}
+        generator.execute()
+
+    assert mock_mkdir.called is False
+
+    assert mock_file().write.call_args_list == [
+        call("Name"),
+        call(":"),
+        call(" "),
+        call("workload-1"),
+        call("\n"),
+        call("Environments"),
+        call(":"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("development"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("testing"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("acceptance"),
+        call("\n"),
+        call("-"),
+        call(" "),
+        call("production"),
+        call("\n"),
+    ]
+    assert mock_file.call_args_list == [
+        call(f"{config_path}/workload-1/info.yaml", "r"),
+        call(f"{config_path}/workload-1/info.yaml", "w"),
+        call(),
+    ]


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

In order to enable git approval flows for your workloads you will need a file structure. The following command will create this structure for you:

```shell
landingzone-organization export workloads "./workloads" "workloads"
```

The following will happen:
1. This will take all the workloads located in the `workloads` organization unit.
2. For each workload a folder is created in the `./workloads` folder.
3. Within the workload folder a: `info.yaml` and a `<ENVIRONMENT>.yaml` per environment is generated.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
